### PR TITLE
Replace Tcl_PanicVA with Tcl_Panic

### DIFF
--- a/generic/tkTableTag.c
+++ b/generic/tkTableTag.c
@@ -212,7 +212,7 @@ TableResetTag(Table *tablePtr, TableTag *tagPtr)
     TableJoinTag *jtagPtr = (TableJoinTag *) tagPtr;
 
     if (jtagPtr->magic != 0x99ABCDEF) {
-      Tcl_PanicVA("bad mojo in TableResetTag",NULL);
+      Tcl_Panic("bad mojo in TableResetTag");
     }
 
     memset((VOID *) jtagPtr, 0, sizeof(TableJoinTag));
@@ -269,7 +269,7 @@ TableMergeTag(Table *tablePtr, TableTag *baseTag, TableTag *addTag)
     unsigned int prio;
 
     if (jtagPtr->magic != 0x99ABCDEF) {
-      Tcl_PanicVA("bad mojo in TableMergeTag",NULL);
+      Tcl_Panic("bad mojo in TableMergeTag");
     }
 
 #ifndef NO_TAG_PRIORITIES
@@ -432,7 +432,7 @@ TableGetTagBorders(TableTag *tagPtr,
 	    if (bottom)	{ *bottom	= tagPtr->bd[3]; }
 	    break;
 	default:
-	    Tcl_PanicVA("invalid border value '%d'\n", tagPtr->borders);
+	    Tcl_Panic("invalid border value '%d'\n", tagPtr->borders);
 	    break;
     }
     return tagPtr->borders;

--- a/generic/tkTableUtil.c
+++ b/generic/tkTableUtil.c
@@ -105,7 +105,7 @@ TableOptionBdSet(clientData, interp, tkwin, value, widgRec, offset)
 	bordersPtr	= &(tagPtr->borders);
 	bdPtr		= tagPtr->bd;
     } else {
-      Tcl_PanicVA("invalid type given to TableOptionBdSet\n",NULL);
+      Tcl_Panic("invalid type given to TableOptionBdSet\n");
 	return TCL_ERROR; /* lint */
     }
 
@@ -188,7 +188,7 @@ TableOptionBdGet(clientData, tkwin, widgRec, offset, freeProcPtr)
     } else if (type == BD_TABLE_WIN) {
 	return ((TableEmbWindow *) widgRec)->borderStr;
     } else {
-      Tcl_PanicVA("invalid type given to TableOptionBdSet\n",NULL);
+      Tcl_Panic("invalid type given to TableOptionBdSet\n");
 	return NULL; /* lint */
     }
 }


### PR DESCRIPTION
`Tcl_PanicVA()` is meant to be used with a precompiles arglist, while the use in tktable is either without arguments, or with plain arguments according to the format string. On some systems, the second required argument of `Tcl_PanicVA()` (`vararglist`) is not a pointer, causing a compilation error when filled with `NULL`.

This PR replaces all appearances with `Tcl_Panic`. Is is tested on Debian; build logs [here](https://buildd.debian.org/status/logs.php?pkg=tk-table&ver=2.10.5-2&suite=sid).

Fixes #2 